### PR TITLE
feat: count mappings in PowerCenter workflow documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ coverage:
 	$(UV) run pytest -q --cov=src --cov-report=term-missing
 
 run:
-	$(UV) run python -m codex_test
+        $(UV) run python -m codex_test $(ARGS)
 
 clean:
 	find . -name "__pycache__" -type d -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 # Create and sync a local environment
 make bootstrap
 
-# Run the app (prints a greeting)
-make run              # or: uv run python -m codex_test
-codex-test Alice      # installed via editable package
+# Run the app (prints the number of mappings in a workflow)
+make run ARGS=path/to/workflow.xml # or: uv run python -m codex_test path/to/workflow.xml
+codex-test path/to/workflow.xml    # installed via editable package
 
 # Run checks
 make fmt && make lint && make typecheck
@@ -23,9 +23,8 @@ make test             # or: make coverage
 ## Usage
 - Module: `codex_test`
 - CLI: `codex-test`
-- Examples:
-  - `python -m codex_test` → "Hello, world!"
-  - `codex-test Alice` → "Hello, Alice!"
+- Example:
+  - `codex-test path/to/workflow.xml` → `3`
 
 ## Project Structure
 ```

--- a/src/codex_test/__init__.py
+++ b/src/codex_test/__init__.py
@@ -1,28 +1,28 @@
-"""Top-level package for codex_test.
-
-Provides a small example API to validate tests and CLI wiring.
-"""
+"""Utilities for working with Informatica PowerCenter workflows."""
 
 from __future__ import annotations
 
-__all__ = [
-    "__version__",
-    "greet",
-]
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+__all__ = ["__version__", "count_mappings"]
 
 __version__ = "0.1.0"
 
 
-def greet(name: str = "world") -> str:
-    """Return a friendly greeting.
+def count_mappings(workflow_path: str | Path) -> int:
+    """Count ``MAPPING`` elements in a workflow document.
 
-    Examples
-    --------
-    >>> greet()
-    'Hello, world!'
-    >>> greet("Alice")
-    'Hello, Alice!'
+    Parameters
+    ----------
+    workflow_path:
+        Path to an Informatica PowerCenter workflow XML document.
+
+    Returns
+    -------
+    int
+        Number of ``MAPPING`` elements found in the document.
     """
 
-    return f"Hello, {name}!"
-
+    tree = ET.parse(workflow_path)
+    return len(tree.findall(".//MAPPING"))

--- a/src/codex_test/__main__.py
+++ b/src/codex_test/__main__.py
@@ -4,7 +4,5 @@ import sys
 
 from .cli import main
 
-
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())
-

--- a/src/codex_test/cli.py
+++ b/src/codex_test/cli.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from . import __version__, greet
+from . import __version__, count_mappings
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="codex-test", description="Example CLI")
-    parser.add_argument("name", nargs="?", default="world", help="Name to greet")
+    parser = argparse.ArgumentParser(
+        prog="codex-test",
+        description="Count mappings in an Informatica PowerCenter workflow document",
+    )
+    parser.add_argument("workflow", type=Path, help="Path to workflow XML document")
     parser.add_argument(
         "--version", action="version", version=f"codex-test {__version__}"
     )
@@ -17,10 +21,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    print(greet(args.name))
+    total = count_mappings(args.workflow)
+    print(total)
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())
-

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import codex_test as pkg
 
+SAMPLE_WORKFLOW = """<?xml version='1.0' encoding='UTF-8'?>
+<REPOSITORY>
+  <FOLDER>
+    <MAPPING NAME='m1'/>
+    <MAPPING NAME='m2'/>
+    <MAPPING NAME='m3'/>
+  </FOLDER>
+</REPOSITORY>
+"""
 
-def test_version_format():
+
+def test_version_format() -> None:
     assert re.match(r"^\d+\.\d+\.\d+$", pkg.__version__)
 
 
-def test_greet_default():
-    assert pkg.greet() == "Hello, world!"
-
-
-def test_greet_custom():
-    assert pkg.greet("Alice") == "Hello, Alice!"
-
+def test_count_mappings(tmp_path: Path) -> None:
+    wf = tmp_path / "wf.xml"
+    wf.write_text(SAMPLE_WORKFLOW)
+    assert pkg.count_mappings(wf) == 3


### PR DESCRIPTION
## Summary
- parse PowerCenter workflow XML and count mapping elements
- expose CLI to output mapping count from a workflow file
- document new workflow counting behavior and update tests

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy src`
- `PYTHONPATH=src uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99f0acb5c833093e58e29352900eb