### PR TITLE
feat(idmc): robust Informatica mapping-to-SQL (IDMC + PowerCenter)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+    src/codex_test/__main__.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ htmlcov/
 .idea/
 .vscode/
 
+# Generated outputs
+output*/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ coverage:
 	$(UV) run pytest -q --cov=src --cov-report=term-missing
 
 run:
-        $(UV) run python -m codex_test $(ARGS)
+	$(UV) run python -m codex_test $(ARGS)
 
 clean:
 	find . -name "__pycache__" -type d -prune -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ coverage:
 	$(UV) run pytest -q --cov=src --cov-report=term-missing
 
 run:
-	$(UV) run python -m codex_test
+        $(UV) run python -m codex_test $(ARGS)
 
 clean:
 	find . -name "__pycache__" -type d -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ make test             # or: make coverage
   - Print SQL to stdout (default).
   - Write files with `--output-dir out/` (one `<mapping>.sql` per mapping).
 
-### Example
-- Input (IDMC JSON):
+### Examples
+- Simple (IDMC JSON):
 ```json
 {
   "mappings": [
@@ -71,6 +71,31 @@ make test             # or: make coverage
 INSERT INTO TGT_TABLE (id, name)
 SELECT id, name
 FROM SRC_TABLE;
+```
+
+- Multi-source join (IDMC JSON):
+```json
+{
+  "mappings": [
+    {
+      "name": "m_join",
+      "sources": [
+        {"name": "SRC_A", "fields": ["id", "name"]},
+        {"name": "SRC_B", "fields": ["id", "amount"]}
+      ],
+      "target": {"name": "TGT", "fields": ["id", "name", "amount"]}
+    }
+  ]
+}
+```
+
+- Output (generated SQL):
+```sql
+-- Mapping: m_join -> TGT
+INSERT INTO TGT (id, name, amount)
+SELECT id, SRC_A.name, SRC_B.amount
+FROM SRC_A
+JOIN SRC_B USING (id);
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 make bootstrap
 
 # Run the app (prints ANSI SQL for each mapping)
-make run ARGS=path/to/workflow.xml # or: uv run python -m codex_test path/to/workflow.xml
-codex-test path/to/workflow.xml    # installed via editable package
+# Supports IDMC JSON or PowerCenter XML
+make run ARGS=path/to/workflow.json # or: uv run python -m codex_test path/to/workflow.json
+codex-test path/to/workflow.json    # installed via editable package
 
 # Run checks
 make fmt && make lint && make typecheck
@@ -24,8 +25,9 @@ make test             # or: make coverage
 - Module: `codex_test`
 - CLI: `codex-test`
 - Example:
-  - `codex-test path/to/workflow.xml` → emits SQL per mapping on stdout
-  - `codex-test path/to/workflow.xml --output-dir out/` → writes one `<mapping>.sql` file per mapping
+  - `codex-test path/to/workflow.json` → emits SQL per mapping on stdout
+  - `codex-test path/to/workflow.json --output-dir out/` → writes one `<mapping>.sql` file per mapping
+  - Also accepts PowerCenter XML for backward compatibility
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ make test             # or: make coverage
   - Print SQL to stdout (default).
   - Write files with `--output-dir out/` (one `<mapping>.sql` per mapping).
 
+### Example
+- Input (IDMC JSON):
+```json
+{
+  "mappings": [
+    {
+      "name": "m_simple",
+      "source": {"name": "SRC_TABLE", "fields": ["id", "name"]},
+      "target": {"name": "TGT_TABLE", "fields": ["id", "name"]}
+    }
+  ]
+}
+```
+
+- Output (generated SQL):
+```sql
+-- Mapping: m_simple -> TGT_TABLE
+INSERT INTO TGT_TABLE (id, name)
+SELECT id, name
+FROM SRC_TABLE;
+```
+
 ## Limitations
 - Advanced Informatica transformations (expressions, filters, lookups, aggregations, conditional logic, etc.) are not currently modeled.
 - Join inference relies on identical column names across sources; aliasing or mapping logic is not interpreted.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 # Create and sync a local environment
 make bootstrap
 
-# Run the app (prints a greeting)
-make run              # or: uv run python -m codex_test
-codex-test Alice      # installed via editable package
+# Run the app (prints the number of mappings in a workflow)
+make run ARGS=path/to/workflow.xml # or: uv run python -m codex_test path/to/workflow.xml
+codex-test path/to/workflow.xml    # installed via editable package
 
 # Run checks
 make fmt && make lint && make typecheck
@@ -23,9 +23,8 @@ make test             # or: make coverage
 ## Usage
 - Module: `codex_test`
 - CLI: `codex-test`
-- Examples:
-  - `python -m codex_test` → "Hello, world!"
-  - `codex-test Alice` → "Hello, Alice!"
+- Example:
+  - `codex-test path/to/workflow.xml` → `3`
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 # Create and sync a local environment
 make bootstrap
 
-# Run the app (prints the number of mappings in a workflow)
+# Run the app (prints ANSI SQL for each mapping)
 make run ARGS=path/to/workflow.xml # or: uv run python -m codex_test path/to/workflow.xml
 codex-test path/to/workflow.xml    # installed via editable package
 
@@ -24,7 +24,8 @@ make test             # or: make coverage
 - Module: `codex_test`
 - CLI: `codex-test`
 - Example:
-  - `codex-test path/to/workflow.xml` → `3`
+  - `codex-test path/to/workflow.xml` → emits SQL per mapping on stdout
+  - `codex-test path/to/workflow.xml --output-dir out/` → writes one `<mapping>.sql` file per mapping
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codex-test
 
-A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-included developer tooling. It uses `uv` for fast environment and dependency management, `pytest` for tests, `ruff`/`black` for lint/format, and `mypy` for optional static typing.
+An Informatica mapping-to-SQL converter. This CLI reads Informatica IDMC (JSON) or PowerCenter (XML) workflow documents and generates ANSI SQL for each mapping. It can print SQL to stdout or write one file per mapping.
 
 ## Requirements
 - Python 3.11+
@@ -11,7 +11,7 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 # Create and sync a local environment
 make bootstrap
 
-# Run the app (prints ANSI SQL for each mapping)
+# Run the converter (prints ANSI SQL for each mapping)
 # Supports Informatica IDMC (JSON) and PowerCenter (XML)
 make run ARGS=path/to/workflow.json # or: uv run python -m codex_test path/to/workflow.json
 codex-test path/to/workflow.json    # installed via editable package

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A minimal, Python 3.11+ project scaffold with a small CLI, tests, and batteries-
 make bootstrap
 
 # Run the app (prints ANSI SQL for each mapping)
-# Supports IDMC JSON or PowerCenter XML
+# Supports Informatica IDMC (JSON) and PowerCenter (XML)
 make run ARGS=path/to/workflow.json # or: uv run python -m codex_test path/to/workflow.json
 codex-test path/to/workflow.json    # installed via editable package
 
@@ -28,6 +28,33 @@ make test             # or: make coverage
   - `codex-test path/to/workflow.json` → emits SQL per mapping on stdout
   - `codex-test path/to/workflow.json --output-dir out/` → writes one `<mapping>.sql` file per mapping
   - Also accepts PowerCenter XML for backward compatibility
+
+## Informatica Conversion
+- **Input formats:**
+  - IDMC workflow JSON (auto-detected by `.json` or JSON content)
+  - PowerCenter workflow XML (legacy support; auto-detected otherwise)
+- **What it does:**
+  - Parses mappings and converts them to ANSI-SQL statements.
+  - Generates `INSERT INTO ... SELECT ...` for each mapping/target.
+- **IDMC features:**
+  - Accepts `source`/`sources` and `target`/`targets` keys.
+  - Reads fields from varied shapes: `fields`, `columns`, `ports`, `schema.fields`, `items` (recursively flattened and de-duplicated, order preserved).
+  - Multiple sources supported:
+    - If sources share common column names, generates `JOIN ... USING(common_cols)`.
+    - If no common columns are found, uses `CROSS JOIN` and adds a comment note.
+  - Multiple targets supported: emits one `INSERT` per target from the same `SELECT`.
+  - Column selection prefers target field order; qualifies non-common columns. Missing columns are projected as `NULL AS <col>`.
+- **PowerCenter features:**
+  - Handles simple cases with a single `Source Definition` and `Target Definition` and their `<FIELD NAME='...'>` entries.
+  - For complex transformations (joins, filters, lookups, etc.), emits a commented placeholder `SELECT`.
+- **Output options:**
+  - Print SQL to stdout (default).
+  - Write files with `--output-dir out/` (one `<mapping>.sql` per mapping).
+
+## Limitations
+- Advanced Informatica transformations (expressions, filters, lookups, aggregations, conditional logic, etc.) are not currently modeled.
+- Join inference relies on identical column names across sources; aliasing or mapping logic is not interpreted.
+- Generated SQL is ANSI-oriented and does not apply vendor-specific dialect features.
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make test             # or: make coverage
 - CLI: `codex-test`
 - Example:
   - `codex-test path/to/workflow.json` → emits SQL per mapping on stdout
-  - `codex-test path/to/workflow.json --output-dir out/` → writes one `<mapping>.sql` file per mapping
+  - `codex-test path/to/workflow.json --output-dir output/` → writes one `<mapping>.sql` file per mapping
   - Also accepts PowerCenter XML for backward compatibility
 
 ## Informatica Conversion

--- a/input/m_join.json
+++ b/input/m_join.json
@@ -1,0 +1,13 @@
+{
+  "mappings": [
+    {
+      "name": "m_join",
+      "sources": [
+        {"name": "SRC_A", "fields": ["id", "name"]},
+        {"name": "SRC_B", "fields": ["id", "amount"]}
+      ],
+      "target": {"name": "TGT", "fields": ["id", "name", "amount"]}
+    }
+  ]
+}
+

--- a/input/m_simple.json
+++ b/input/m_simple.json
@@ -1,0 +1,9 @@
+{
+  "mappings": [
+    {
+      "name": "m_simple",
+      "source": {"name": "SRC_TABLE", "fields": ["id", "name"]},
+      "target": {"name": "TGT_TABLE", "fields": ["id", "name"]}
+    }
+  ]
+}

--- a/input/package.json
+++ b/input/package.json
@@ -1,0 +1,256 @@
+{
+  "info": {
+    "exportDate": "2025-09-05T00:00:00Z",
+    "product": "Informatica Intelligent Data Management Cloud (IDMC)",
+    "service": "Cloud Data Integration",
+    "formatVersion": "3.0",
+    "notes": "Sample package: OLTP MySQL source to Oracle target. Replace connection creds/paths/objects for your tenant."
+  },
+  "objects": [
+    {
+      "type": "CONNECTION",
+      "id": "CONN_mysql",
+      "name": "cnx_MySQL_OLTP_DEMO",
+      "subtype": "MySQL",
+      "folderPath": "/Samples/OLTP2Oracle/Connections",
+      "properties": {
+        "host": "mysql-oltp.example.local",
+        "port": 3306,
+        "database": "appdb",
+        "username": "svc_idmc",
+        "secureFields": { "password": "${secure:MYSQL_PWD}" },
+        "sslMode": "PREFERRED"
+      }
+    },
+    {
+      "type": "CONNECTION",
+      "id": "CONN_oracle",
+      "name": "cnx_Oracle_DWH_DEMO",
+      "subtype": "Oracle",
+      "folderPath": "/Samples/OLTP2Oracle/Connections",
+      "properties": {
+        "host": "oracle-dwh.example.local",
+        "port": 1521,
+        "serviceName": "ORCLPDB1",
+        "username": "DWH_USER",
+        "secureFields": { "password": "${secure:ORACLE_PWD}" }
+      }
+    },
+
+    {
+      "type": "MAPPING",
+      "id": "MAP_dim",
+      "name": "m_OLTP_Customers_to_DIM_CUSTOMER",
+      "folderPath": "/Samples/OLTP2Oracle/Project",
+      "description": "Incrementally upsert OLTP customers into Oracle DIM_CUSTOMER using a watermark on updated_at.",
+      "parameters": [
+        { "name": "p_SrcTable", "type": "String", "default": "customers" },
+        { "name": "p_TgtTable", "type": "String", "default": "DIM_CUSTOMER" },
+        { "name": "p_Watermark", "type": "String", "default": "1970-01-01 00:00:00" }
+      ],
+      "sources": [
+        {
+          "name": "src_Customers",
+          "connectionId": "CONN_mysql",
+          "object": "${p_SrcTable}",
+          "filter": "updated_at > TO_TIMESTAMP('${p_Watermark}')",
+          "fields": [
+            { "name": "id", "type": "integer" },
+            { "name": "first_name", "type": "string" },
+            { "name": "last_name", "type": "string" },
+            { "name": "email", "type": "string" },
+            { "name": "updated_at", "type": "timestamp" }
+          ]
+        }
+      ],
+      "transformations": [
+        {
+          "type": "Expression",
+          "name": "exp_Normalize",
+          "fields": [
+            { "name": "CUSTOMER_KEY", "expr": "id" },
+            { "name": "FIRST_NAME", "expr": "INITCAP(TRIM(first_name))" },
+            { "name": "LAST_NAME", "expr": "INITCAP(TRIM(last_name))" },
+            { "name": "EMAIL", "expr": "LOWER(TRIM(email))" },
+            { "name": "EFFECTIVE_FROM", "expr": "SYSDATE()" }
+          ]
+        }
+      ],
+      "targets": [
+        {
+          "name": "tgt_DIM_CUSTOMER",
+          "connectionId": "CONN_oracle",
+          "object": "${p_TgtTable}",
+          "operation": "UPSERT",
+          "keys": ["CUSTOMER_KEY"],
+          "fieldMapping": [
+            { "source": "CUSTOMER_KEY", "target": "CUSTOMER_KEY" },
+            { "source": "FIRST_NAME", "target": "FIRST_NAME" },
+            { "source": "LAST_NAME", "target": "LAST_NAME" },
+            { "source": "EMAIL", "target": "EMAIL" },
+            { "source": "EFFECTIVE_FROM", "target": "EFFECTIVE_FROM" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "type": "MAPPING",
+      "id": "MAP_fact",
+      "name": "m_OLTP_Orders_to_FACT_ORDER",
+      "folderPath": "/Samples/OLTP2Oracle/Project",
+      "description": "Load transactional orders into Oracle FACT_ORDER with derived measures; incremental by updated_at.",
+      "parameters": [
+        { "name": "p_SrcTable", "type": "String", "default": "orders" },
+        { "name": "p_TgtTable", "type": "String", "default": "FACT_ORDER" },
+        { "name": "p_Watermark", "type": "String", "default": "1970-01-01 00:00:00" }
+      ],
+      "sources": [
+        {
+          "name": "src_Orders",
+          "connectionId": "CONN_mysql",
+          "object": "${p_SrcTable}",
+          "filter": "updated_at > TO_TIMESTAMP('${p_Watermark}')",
+          "fields": [
+            { "name": "order_id", "type": "integer" },
+            { "name": "customer_id", "type": "integer" },
+            { "name": "product_id", "type": "integer" },
+            { "name": "unit_price", "type": "decimal" },
+            { "name": "quantity", "type": "integer" },
+            { "name": "order_dt", "type": "date" },
+            { "name": "updated_at", "type": "timestamp" }
+          ]
+        }
+      ],
+      "transformations": [
+        {
+          "type": "Expression",
+          "name": "exp_Calc",
+          "fields": [
+            { "name": "AMOUNT", "expr": "unit_price * quantity" },
+            { "name": "LOAD_TS", "expr": "SYSDATE()" }
+          ]
+        }
+      ],
+      "targets": [
+        {
+          "name": "tgt_FACT_ORDER",
+          "connectionId": "CONN_oracle",
+          "object": "${p_TgtTable}",
+          "operation": "UPSERT",
+          "keys": ["ORDER_ID"],
+          "fieldMapping": [
+            { "source": "order_id", "target": "ORDER_ID" },
+            { "source": "customer_id", "target": "CUSTOMER_KEY" },
+            { "source": "product_id", "target": "PRODUCT_ID" },
+            { "source": "AMOUNT", "target": "AMOUNT" },
+            { "source": "order_dt", "target": "ORDER_DT" },
+            { "source": "LOAD_TS", "target": "LOAD_TS" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "type": "MAPPING_TASK",
+      "id": "MTTASK_dim",
+      "name": "mt_DIM_CUSTOMER_Incremental",
+      "folderPath": "/Samples/OLTP2Oracle/Project",
+      "mappingId": "MAP_dim",
+      "description": "Runs customer dim upsert with watermark param.",
+      "runtimeEnvironment": "Default",
+      "parameterValues": {
+        "p_SrcTable": "customers",
+        "p_TgtTable": "DIM_CUSTOMER",
+        "p_Watermark": "${secure:WM_CUSTOMERS}"
+      },
+      "advancedSessionProperties": {
+        "logLevel": "Normal",
+        "errorLimit": 0
+      },
+      "schedule": {
+        "enabled": true,
+        "type": "CRON",
+        "cron": "0 0/30 * * * ?",
+        "timezone": "America/Chicago"
+      }
+    },
+
+    {
+      "type": "MAPPING_TASK",
+      "id": "MTTASK_fact",
+      "name": "mt_FACT_ORDER_Incremental",
+      "folderPath": "/Samples/OLTP2Oracle/Project",
+      "mappingId": "MAP_fact",
+      "description": "Runs orders fact upsert with watermark param.",
+      "runtimeEnvironment": "Default",
+      "parameterValues": {
+        "p_SrcTable": "orders",
+        "p_TgtTable": "FACT_ORDER",
+        "p_Watermark": "${secure:WM_ORDERS}"
+      },
+      "advancedSessionProperties": {
+        "logLevel": "Normal",
+        "errorLimit": 5
+      },
+      "schedule": {
+        "enabled": true,
+        "type": "CRON",
+        "cron": "0 5/30 * * * ?",
+        "timezone": "America/Chicago"
+      }
+    },
+
+    {
+      "type": "TASKFLOW",
+      "id": "TASKFLOW_main",
+      "name": "tf_OLTP_to_Oracle_Incremental",
+      "folderPath": "/Samples/OLTP2Oracle/Project",
+      "description": "Runs DIM then FACT with simple success chaining and failure email.",
+      "start": "Start",
+      "steps": [
+        { "id": "Start", "type": "Start" },
+        {
+          "id": "S_DIM",
+          "type": "Task",
+          "taskType": "MAPPING_TASK",
+          "refId": "MTTASK_dim",
+          "onSuccess": "S_FACT",
+          "onFailure": "Fail"
+        },
+        {
+          "id": "S_FACT",
+          "type": "Task",
+          "taskType": "MAPPING_TASK",
+          "refId": "MTTASK_fact",
+          "onSuccess": "End",
+          "onFailure": "Fail"
+        },
+        {
+          "id": "Fail",
+          "type": "Assignment",
+          "assign": [{ "name": "v_Status", "value": "'FAILED'" }],
+          "onSuccess": "Notify"
+        },
+        {
+          "id": "Notify",
+          "type": "Notification",
+          "emailTo": "${p_NotifyEmail}",
+          "subject": "Taskflow Failure: ${v_Status}",
+          "body": "Check logs in IDMC."
+        },
+        { "id": "End", "type": "End" }
+      ],
+      "parameters": [
+        { "name": "p_NotifyEmail", "type": "String", "default": "dataops@example.com" }
+      ]
+    }
+  ],
+
+  "dependencies": [
+    { "from": "MTTASK_dim", "to": "MAP_dim" },
+    { "from": "MTTASK_fact", "to": "MAP_fact" },
+    { "from": "TASKFLOW_main", "to": "MTTASK_dim" },
+    { "from": "TASKFLOW_main", "to": "MTTASK_fact" }
+  ]
+}

--- a/src/codex_test/__init__.py
+++ b/src/codex_test/__init__.py
@@ -1,28 +1,28 @@
-"""Top-level package for codex_test.
-
-Provides a small example API to validate tests and CLI wiring.
-"""
+"""Utilities for working with Informatica PowerCenter workflows."""
 
 from __future__ import annotations
 
-__all__ = [
-    "__version__",
-    "greet",
-]
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+__all__ = ["__version__", "count_mappings"]
 
 __version__ = "0.1.0"
 
 
-def greet(name: str = "world") -> str:
-    """Return a friendly greeting.
+def count_mappings(workflow_path: str | Path) -> int:
+    """Count ``MAPPING`` elements in a workflow document.
 
-    Examples
-    --------
-    >>> greet()
-    'Hello, world!'
-    >>> greet("Alice")
-    'Hello, Alice!'
+    Parameters
+    ----------
+    workflow_path:
+        Path to an Informatica PowerCenter workflow XML document.
+
+    Returns
+    -------
+    int
+        Number of ``MAPPING`` elements found in the document.
     """
 
-    return f"Hello, {name}!"
-
+    tree = ET.parse(workflow_path)
+    return len(tree.findall(".//MAPPING"))

--- a/src/codex_test/__init__.py
+++ b/src/codex_test/__init__.py
@@ -1,11 +1,25 @@
-"""Utilities for working with Informatica PowerCenter workflows."""
+"""Utilities for working with Informatica PowerCenter workflows.
+
+This module provides minimal parsing of Informatica PowerCenter workflow XML
+documents and a best-effort conversion of simple mappings to ANSI SQL. The
+conversion supports basic cases where a mapping contains a single source and a
+single target definition with fields. Complex transformations (joins, filters,
+aggregations, expressions, lookups, etc.) are not modeled and will result in a
+placeholder SQL statement.
+"""
 
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-__all__ = ["__version__", "count_mappings"]
+from typing import Dict, List
+
+__all__ = [
+    "__version__",
+    "count_mappings",
+    "convert_mappings_to_sql",
+]
 
 __version__ = "0.1.0"
 
@@ -26,3 +40,101 @@ def count_mappings(workflow_path: str | Path) -> int:
 
     tree = ET.parse(workflow_path)
     return len(tree.findall(".//MAPPING"))
+
+
+def _text_identifier(name: str | None) -> str:
+    """Return a safe identifier for SQL output.
+
+    Currently this performs a minimal pass-through and is intended to keep the
+    output ANSI-SQL flavoured without vendor specifics. In the future this could
+    quote or sanitize reserved words.
+    """
+
+    return (name or "").strip()
+
+
+def _fields_from_transformation(xform: ET.Element) -> List[str]:
+    return [f.get("NAME", "").strip() for f in xform.findall("FIELD") if f.get("NAME")]
+
+
+def _first_child(elem: ET.Element, xpath: str) -> ET.Element | None:
+    found = elem.findall(xpath)
+    return found[0] if found else None
+
+
+def convert_mappings_to_sql(workflow_path: str | Path) -> Dict[str, str]:
+    """Convert each mapping in a workflow to a best-effort ANSI-SQL string.
+
+    The converter handles simple patterns where a mapping declares one source
+    transformation (TYPE contains "Source") and one target transformation (TYPE
+    contains "Target"). When fields are present under the target (preferred) or
+    source, it creates an INSERT INTO ... SELECT ... statement mapping like-named
+    columns. For unrecognized or underspecified mappings, a placeholder SELECT
+    with a comment is produced.
+
+    Parameters
+    ----------
+    workflow_path:
+        Path to an Informatica PowerCenter workflow XML document.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping name to generated SQL text.
+    """
+
+    tree = ET.parse(workflow_path)
+    root = tree.getroot()
+
+    sql_by_mapping: Dict[str, str] = {}
+
+    for m in root.findall(".//MAPPING"):
+        m_name = m.get("NAME") or "UNKNOWN_MAPPING"
+        # Find source/target transformations inside the mapping
+        xforms = list(m.findall("TRANSFORMATION"))
+        srcs = [x for x in xforms if (x.get("TYPE") or "").lower().startswith("source")]
+        tgts = [x for x in xforms if (x.get("TYPE") or "").lower().startswith("target")]
+
+        src = srcs[0] if len(srcs) == 1 else None
+        tgt = tgts[0] if len(tgts) == 1 else None
+
+        if src is not None and tgt is not None:
+            src_name = _text_identifier(src.get("NAME")) or "SOURCE"
+            tgt_name = _text_identifier(tgt.get("NAME")) or "TARGET"
+
+            tgt_fields = [f for f in _fields_from_transformation(tgt) if f]
+            src_fields = [f for f in _fields_from_transformation(src) if f]
+
+            # Prefer intersection of target and source fields, maintain target order
+            if tgt_fields and src_fields:
+                src_set = {f.lower() for f in src_fields}
+                cols = [c for c in tgt_fields if c.lower() in src_set]
+            else:
+                # Fall back to whichever side has fields; if neither, use '*'
+                cols = tgt_fields or src_fields
+
+            if cols:
+                cols_csv = ", ".join(cols)
+                sql = (
+                    f"-- Mapping: {m_name}\n"
+                    f"INSERT INTO {tgt_name} ({cols_csv})\n"
+                    f"SELECT {cols_csv} FROM {src_name};\n"
+                )
+            else:
+                sql = (
+                    f"-- Mapping: {m_name} (no fields found)\n"
+                    f"-- Unable to infer columns; emitting broad SELECT.\n"
+                    f"INSERT INTO {tgt_name}\n"
+                    f"SELECT * FROM {src_name};\n"
+                )
+        else:
+            # Could not infer source/target; emit a placeholder
+            sql = (
+                f"-- Mapping: {m_name} (unsupported or underspecified)\n"
+                f"-- No clear single source/target; manual conversion required.\n"
+                f"SELECT /* mapping {m_name} */ *;\n"
+            )
+
+        sql_by_mapping[m_name] = sql
+
+    return sql_by_mapping

--- a/src/codex_test/__main__.py
+++ b/src/codex_test/__main__.py
@@ -4,7 +4,5 @@ import sys
 
 from .cli import main
 
-
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())
-

--- a/src/codex_test/cli.py
+++ b/src/codex_test/cli.py
@@ -11,7 +11,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="codex-test",
         description=(
-            "Convert Informatica PowerCenter mappings in a workflow XML to ANSI SQL"
+            "Convert Informatica mappings to ANSI SQL (IDMC JSON or PowerCenter XML)"
         ),
     )
     parser.add_argument("workflow", type=Path, help="Path to workflow XML document")

--- a/src/codex_test/cli.py
+++ b/src/codex_test/cli.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from . import __version__, greet
+from . import __version__, count_mappings
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="codex-test", description="Example CLI")
-    parser.add_argument("name", nargs="?", default="world", help="Name to greet")
+    parser = argparse.ArgumentParser(
+        prog="codex-test",
+        description="Count mappings in an Informatica PowerCenter workflow document",
+    )
+    parser.add_argument("workflow", type=Path, help="Path to workflow XML document")
     parser.add_argument(
         "--version", action="version", version=f"codex-test {__version__}"
     )
@@ -17,10 +21,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    print(greet(args.name))
+    total = count_mappings(args.workflow)
+    print(total)
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())
-

--- a/tests/codex_test/test_cli.py
+++ b/tests/codex_test/test_cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+import sys
+
+import pytest
+
+import codex_test as pkg
+from codex_test.cli import main, parse_args
+
+
+def test_parse_args_default():
+    args = parse_args([])
+    assert args.name == "world"
+
+
+def test_parse_args_custom():
+    args = parse_args(["Alice"])
+    assert args.name == "Alice"
+
+
+def test_main_default_prints_and_returns_zero(capsys: pytest.CaptureFixture[str]):
+    code = main([])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "Hello, world!\n"
+
+
+def test_main_custom_prints_and_returns_zero(capsys: pytest.CaptureFixture[str]):
+    code = main(["Alice"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "Hello, Alice!\n"
+
+
+def test_version_flag_prints_and_exits(capsys: pytest.CaptureFixture[str]):
+    # argparse's version action prints to stdout and exits with code 0
+    with pytest.raises(SystemExit) as exc:
+        parse_args(["--version"])  # triggers SystemExit
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert out == f"codex-test {pkg.__version__}\n"
+

--- a/tests/codex_test/test_cli.py
+++ b/tests/codex_test/test_cli.py
@@ -7,7 +7,6 @@ import pytest
 import codex_test as pkg
 from codex_test.cli import main, parse_args
 
-
 SIMPLE_MAPPING = """<?xml version='1.0' encoding='UTF-8'?>
 <REPOSITORY>
   <FOLDER>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import codex_test as pkg
 
+SAMPLE_WORKFLOW = """<?xml version='1.0' encoding='UTF-8'?>
+<REPOSITORY>
+  <FOLDER>
+    <MAPPING NAME='m1'/>
+    <MAPPING NAME='m2'/>
+    <MAPPING NAME='m3'/>
+  </FOLDER>
+</REPOSITORY>
+"""
 
-def test_version_format():
+
+def test_version_format() -> None:
     assert re.match(r"^\d+\.\d+\.\d+$", pkg.__version__)
 
 
-def test_greet_default():
-    assert pkg.greet() == "Hello, world!"
-
-
-def test_greet_custom():
-    assert pkg.greet("Alice") == "Hello, Alice!"
-
+def test_count_mappings(tmp_path: Path) -> None:
+    wf = tmp_path / "wf.xml"
+    wf.write_text(SAMPLE_WORKFLOW)
+    assert pkg.count_mappings(wf) == 3

--- a/tests/test_idmc.py
+++ b/tests/test_idmc.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import codex_test as pkg
+
+
+SIMPLE_IDMC = {
+    "mappings": [
+        {
+            "name": "m_simple",
+            "source": {"name": "SRC_TABLE", "fields": ["id", "name"]},
+            "target": {"name": "TGT_TABLE", "fields": ["id", "name"]},
+        }
+    ]
+}
+
+
+def test_count_mappings_idmc(tmp_path: Path) -> None:
+    wf = tmp_path / "wf.json"
+    wf.write_text(__import__("json").dumps(SIMPLE_IDMC))
+    assert pkg.count_mappings(wf) == 1
+
+
+def test_convert_mappings_to_sql_idmc(tmp_path: Path) -> None:
+    wf = tmp_path / "wf.json"
+    wf.write_text(__import__("json").dumps(SIMPLE_IDMC))
+    out = pkg.convert_mappings_to_sql(wf)
+    assert set(out.keys()) == {"m_simple"}
+    sql = out["m_simple"]
+    assert "INSERT INTO TGT_TABLE (id, name)" in sql
+    assert "SELECT id, name FROM SRC_TABLE;" in sql
+

--- a/tests/test_idmc.py
+++ b/tests/test_idmc.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import codex_test as pkg
 
-
 SIMPLE_IDMC = {
     "mappings": [
         {
@@ -30,4 +29,3 @@ def test_convert_mappings_to_sql_idmc(tmp_path: Path) -> None:
     sql = out["m_simple"]
     assert "INSERT INTO TGT_TABLE (id, name)" in sql
     assert "SELECT id, name FROM SRC_TABLE;" in sql
-

--- a/tests/test_idmc.py
+++ b/tests/test_idmc.py
@@ -28,4 +28,5 @@ def test_convert_mappings_to_sql_idmc(tmp_path: Path) -> None:
     assert set(out.keys()) == {"m_simple"}
     sql = out["m_simple"]
     assert "INSERT INTO TGT_TABLE (id, name)" in sql
-    assert "SELECT id, name FROM SRC_TABLE;" in sql
+    assert "SELECT id, name" in sql
+    assert "FROM SRC_TABLE;" in sql

--- a/tests/test_idmc_advanced.py
+++ b/tests/test_idmc_advanced.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import codex_test as pkg
+
+
+def test_idmc_multiple_sources_join(tmp_path: Path) -> None:
+    data = {
+        "mappings": [
+            {
+                "name": "m_join",
+                "sources": [
+                    {"name": "SRC_A", "fields": ["id", "name"]},
+                    {"name": "SRC_B", "fields": ["id", "amount"]},
+                ],
+                "target": {"name": "TGT", "fields": ["id", "name", "amount"]},
+            }
+        ]
+    }
+    wf = tmp_path / "wf.json"
+    wf.write_text(json.dumps(data))
+    out = pkg.convert_mappings_to_sql(wf)
+    sql = out["m_join"]
+    assert "JOIN SRC_B USING (id)" in sql
+    # id is unqualified due to USING; name and amount are qualified
+    assert "SELECT id, SRC_A.name, SRC_B.amount" in sql
+    assert "INSERT INTO TGT (id, name, amount)" in sql
+
+
+def test_idmc_multiple_sources_cross_join(tmp_path: Path) -> None:
+    data = {
+        "mappings": [
+            {
+                "name": "m_cross",
+                "sources": [
+                    {"name": "A", "fields": ["a_id", "val_a"]},
+                    {"name": "B", "fields": ["b_id", "val_b"]},
+                ],
+                "target": {"name": "TGT", "fields": ["a_id", "b_id"]},
+            }
+        ]
+    }
+    wf = tmp_path / "wf.json"
+    wf.write_text(json.dumps(data))
+    out = pkg.convert_mappings_to_sql(wf)
+    sql = out["m_cross"]
+    assert "CROSS JOIN B" in sql
+    # Columns qualified from their owning source
+    assert "SELECT A.a_id, B.b_id" in sql
+    assert "INSERT INTO TGT (a_id, b_id)" in sql
+
+
+def test_idmc_multiple_targets(tmp_path: Path) -> None:
+    data = {
+        "mappings": [
+            {
+                "name": "m_multi_tgt",
+                "source": {"name": "SRC", "fields": ["id", "name"]},
+                "targets": [
+                    {"name": "T1", "fields": ["id"]},
+                    {"name": "T2", "fields": ["name"]},
+                ],
+            }
+        ]
+    }
+    wf = tmp_path / "wf.json"
+    wf.write_text(json.dumps(data))
+    out = pkg.convert_mappings_to_sql(wf)
+    sql = out["m_multi_tgt"]
+    assert "INSERT INTO T1 (id)" in sql
+    assert "INSERT INTO T2 (name)" in sql
+
+
+def test_idmc_field_shapes(tmp_path: Path) -> None:
+    data = {
+        "mappings": [
+            {
+                "name": "m_shapes",
+                "sources": [
+                    {
+                        "name": "SRC1",
+                        "schema": {"fields": [{"name": "id"}, {"name": "name"}]},
+                    },
+                    {"name": "SRC2", "columns": ["id", {"name": "amount"}]},
+                ],
+                "target": {"name": "TGT", "ports": ["id", "name", "amount"]},
+            }
+        ]
+    }
+    wf = tmp_path / "wf.json"
+    wf.write_text(json.dumps(data))
+    out = pkg.convert_mappings_to_sql(wf)
+    sql = out["m_shapes"]
+    # Should detect common 'id' for JOIN
+    assert "JOIN SRC2 USING (id)" in sql
+    # Qualify non-common columns
+    assert "SELECT id, SRC1.name, SRC2.amount" in sql

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import codex_test as pkg
 
-
 SIMPLE_MAPPING = """<?xml version='1.0' encoding='UTF-8'?>
 <REPOSITORY>
   <FOLDER>
@@ -19,7 +18,7 @@ SIMPLE_MAPPING = """<?xml version='1.0' encoding='UTF-8'?>
       </TRANSFORMATION>
     </MAPPING>
   </FOLDER>
-  
+
 </REPOSITORY>
 """
 
@@ -32,4 +31,3 @@ def test_convert_mappings_to_sql_basic(tmp_path: Path) -> None:
     sql = out["m_simple"]
     assert "INSERT INTO TGT_TABLE (id, name)" in sql
     assert "SELECT id, name FROM SRC_TABLE;" in sql
-

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import codex_test as pkg
+
+
+SIMPLE_MAPPING = """<?xml version='1.0' encoding='UTF-8'?>
+<REPOSITORY>
+  <FOLDER>
+    <MAPPING NAME='m_simple'>
+      <TRANSFORMATION NAME='SRC_TABLE' TYPE='Source Definition'>
+        <FIELD NAME='id'/>
+        <FIELD NAME='name'/>
+      </TRANSFORMATION>
+      <TRANSFORMATION NAME='TGT_TABLE' TYPE='Target Definition'>
+        <FIELD NAME='id'/>
+        <FIELD NAME='name'/>
+      </TRANSFORMATION>
+    </MAPPING>
+  </FOLDER>
+  
+</REPOSITORY>
+"""
+
+
+def test_convert_mappings_to_sql_basic(tmp_path: Path) -> None:
+    wf = tmp_path / "wf.xml"
+    wf.write_text(SIMPLE_MAPPING)
+    out = pkg.convert_mappings_to_sql(wf)
+    assert set(out.keys()) == {"m_simple"}
+    sql = out["m_simple"]
+    assert "INSERT INTO TGT_TABLE (id, name)" in sql
+    assert "SELECT id, name FROM SRC_TABLE;" in sql
+


### PR DESCRIPTION
Adds IDMC JSON support with auto-detection alongside PowerCenter XML.
Generates ANSI SQL; supports multi-source JOIN/CROSS JOIN, multiple targets, varied field schemas.
CLI prints or writes per-mapping files via --output-dir (top-level output*/ ignored by git).
Tests: 12 passing; lint and mypy clean.
README updated with features and examples.