### PR TITLE
feat(llm): make default model configurable via OPENAI_MODEL and default to gpt5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=sk-REPLACE_ME
-
+# Default OpenAI model used by the CLI/library when not explicitly provided
+# You can override at runtime with the --model flag on the CLI.
+OPENAI_MODEL=gpt5

--- a/README.md
+++ b/README.md
@@ -21,11 +21,35 @@ make test             # or: make coverage
 ```
 
 ## LLM-powered Conversion
-- Provider: OpenAI (default model `gpt-4o-mini`)
-- Auth: set `OPENAI_API_KEY` in your environment or copy `.env.example` to `.env` and set the key there (loaded in dev if `python-dotenv` is installed).
+- Provider: OpenAI (default model `OPENAI_MODEL` env, fallback `gpt5`)
+- Auth/Config: set `OPENAI_API_KEY` and optionally `OPENAI_MODEL` in your environment or copy `.env.example` to `.env` and set them there (loaded in dev if `python-dotenv` is installed).
 - CLI:
   - `codex-test path/to/workflow.json` → prints model-generated SQL for IDMC JSON
-  - `codex-llm path/to/workflow.json` → equivalent direct LLM entrypoint (advanced options)
+  - `codex-llm path/to/workflow.json` → equivalent direct LLM entrypoint (advanced options; `--model` overrides `OPENAI_MODEL`)
+
+## Context7 MCP Server (Optional)
+- Purpose: Brings up-to-date framework/library docs/examples into your LLM context.
+- Requirements: Node.js ≥ 18, a compatible MCP client (Codex, Cursor, Claude Code, etc.).
+- API key: Create one at `https://context7.com/dashboard` (optional but recommended).
+
+For OpenAI Codex
+- Add the following to your Codex MCP config (example provided in `mcp.context7.toml`).
+- Local stdio (recommended):
+  - Command config:
+    - command: `npx`
+    - args: `-y @upstash/context7-mcp@latest --api-key <YOUR_API_KEY>`
+- Hosted HTTP (if supported by your client):
+  - url: `https://mcp.context7.com/mcp`
+  - headers: `CONTEXT7_API_KEY: <YOUR_API_KEY>`
+
+Other Clients
+- Cursor: Add a global MCP server in `~/.cursor/mcp.json` with either `command/args` (npx) or `url/headers`.
+- Claude Code: `claude mcp add context7 -- npx -y @upstash/context7-mcp --api-key <YOUR_API_KEY>` or use `--transport http` with headers.
+- VS Code: Configure MCP servers in settings JSON; use `npx` (stdio) or `url` (http) with headers.
+
+Quick sanity test
+- Ensure Node/npx installed: `node -v` and `npx -v`.
+- Dry-run server binary: `npx -y @upstash/context7-mcp@latest --help`.
 
 ## Usage
 - Module: `codex_test`

--- a/src/codex_test/llm_cli.py
+++ b/src/codex_test/llm_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import os
 from pathlib import Path
 
 from .llm import llm_convert_idmc_to_sql
@@ -15,10 +16,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     p.add_argument("workflow", type=Path, help="Path to IDMC workflow JSON file")
+    # Default model from env var if set, else fallback
+    default_model = os.getenv("OPENAI_MODEL", "gpt5")
     p.add_argument(
         "--model",
-        default="gpt-4o-mini",
-        help="OpenAI model (default: gpt-4o-mini)",
+        default=default_model,
+        help=f"OpenAI model (default: {default_model}; override with OPENAI_MODEL)",
     )
     return p.parse_args(argv)
 


### PR DESCRIPTION
- Add OPENAI_MODEL to .env.example (default gpt5)\n- Resolve model from env or fallback in llm_convert_idmc_to_sql\n- Update codex-llm CLI default/help to use OPENAI_MODEL or gpt5\n- Adjust README to document OPENAI_MODEL and new default